### PR TITLE
Add npm init and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Fetch the ZoneMTA application template
 ```
 $ git clone git://github.com/zone-eu/zone-mta-template.git
 $ cd zone-mta-template
+$ npm install eslint --save-dev
+$ npm init
 $ npm install --production
 $ npm start
 ```


### PR DESCRIPTION
Newest node.js version (on ubuntu 18.04) requires npm init to create json.
Fix eslint dependencies warning.